### PR TITLE
Fix compilation on Debian 12

### DIFF
--- a/include/xc/utility.hpp
+++ b/include/xc/utility.hpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 #include <iostream>
+#include <iomanip>
+#include <sstream>
 
 namespace xc
 {

--- a/include/xc/xcmake.hpp
+++ b/include/xc/xcmake.hpp
@@ -5,8 +5,7 @@
 #include <xc/utility.hpp>
 
 
-
-#include <format>
+#include <fmt/core.h>
 #include <functional>
 #include <iostream>
 #include <ranges>
@@ -83,13 +82,13 @@ namespace xc
     template<typename... Args>
     void xcmake::error(std::string_view message, Args&&... args) const
     {
-        std::cout << "[xc] [xc:" + color("error", "101") + "] " << std::vformat(message, std::make_format_args(args...)) << std::endl;
+        std::cout << "[xc] [xc:" + color("error", "101") + "] " << fmt::vformat(message, fmt::make_format_args(args...)) << std::endl;
     }
 
     template<typename... Args>
     void xcmake::log(std::string_view message, Args&&... args) const
     {
-        std::cout << color("[xc]", "34") << " " << std::vformat(message, std::make_format_args(args...)) << std::endl;
+        std::cout << color("[xc]", "34") << " " << fmt::vformat(message, fmt::make_format_args(args...)) << std::endl;
     }
 } // xc
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -2,9 +2,9 @@ add_rules("mode.debug", "mode.release")
 set_languages("cxx20")
 
 add_repositories("local repo")
-add_requires("tiny-process-library")
+add_requires("fmt", "tiny-process-library")
 
 target("xc")
     add_files("source/**.cpp")
     add_includedirs("include")
-    add_packages("tiny-process-library")
+    add_packages("fmt", "tiny-process-library")


### PR DESCRIPTION
Debian 12 comes with GCC 12 which doesn't have <format>, use fmt instead